### PR TITLE
Reduce merge conflicts when merging into master

### DIFF
--- a/git-flow-hotfix
+++ b/git-flow-hotfix
@@ -254,7 +254,7 @@ cmd_finish() {
 	if ! git_is_branch_merged_into "$BRANCH" "$MASTER_BRANCH"; then
 		git checkout "$MASTER_BRANCH" || \
 		  die "Could not check out $MASTER_BRANCH."
-		git merge --no-ff "$BRANCH" || \
+		git merge --no-ff -srecursive -Xtheirs "$BRANCH" || \
 		  die "There were merge conflicts."
 		  # TODO: What do we do now?
 	fi

--- a/git-flow-release
+++ b/git-flow-release
@@ -225,7 +225,7 @@ cmd_finish() {
 	if ! git_is_branch_merged_into "$BRANCH" "$MASTER_BRANCH"; then
 		git checkout "$MASTER_BRANCH" || \
 		  die "Could not check out $MASTER_BRANCH."
-		git merge --no-ff "$BRANCH" || \
+		git merge --no-ff -srecursive -Xtheirs "$BRANCH" || \
 		  die "There were merge conflicts."
 		  # TODO: What do we do now?
 	fi


### PR DESCRIPTION
- When merging into master branch, give a hint to the merge engine to
  tell it that we prefer the hotfix or release to take precedence
  where possible.

Source: https://github.com/nvie/gitflow/pull/153
