### PR TITLE
Push after update

### DIFF
--- a/git-flow-update
+++ b/git-flow-update
@@ -136,9 +136,11 @@ cmd_update() {
 
 	# merge the master branch
 	helper_merge "$ORIGIN" "$MASTER_BRANCH"
+	git push || die "Push to github failed"
 
 	# merge the develop branch
 	helper_merge "$ORIGIN" "$DEVELOP_BRANCH"
+	git push || die "Push to github failed"
 
 	# switch back to the branch that the user was on
 	git checkout $current_branch


### PR DESCRIPTION
This should stop the unnecessary 'your branch is ahead of origin/blah by X commits' messages
