### PR TITLE
Feature/finish no merge

### DIFF
--- a/git-hf-feature
+++ b/git-hf-feature
@@ -338,6 +338,7 @@ cmd_finish() {
 	DEFINE_boolean rebase false "rebase instead of merge" r
 	DEFINE_boolean keep false "keep branch after performing finish" k
 	DEFINE_boolean force_delete false "force delete feature branch after finish" D
+	DEFINE_boolean force_merge false "force merge of feature branch if not merged yet at origin" f
 	parse_args "$@"
 	expand_nameprefix_arg_or_current
 
@@ -404,14 +405,13 @@ cmd_finish() {
 	fi
 
 	# make sure that the feature branch has been merged into develop
-	if [[ $(git rev-list -n2 "$DEVELOP_BRANCH..$BRANCH") ]] ; then
-		echo "Feature branch has not yet been merged into $DEVELOP_BRANCH."
-		echo "Please raise a pull-request via GitHub first."
-		exit 1
+	if noflag force_merge ; then
+		if [[ $(git rev-list -n2 "$DEVELOP_BRANCH..$BRANCH") ]] ; then
+			echo "Feature branch has not yet been merged into $DEVELOP_BRANCH."
+			echo "Please raise a pull-request via GitHub first."
+			exit 1
+		fi
 	fi
-	# stop here for the moment, until the above block works
-	echo "Merged test passed; stopping for now"
-	exit 1
 
 	# if the user wants to rebase, do that first
 	if flag rebase; then


### PR DESCRIPTION
New: cannot finish a feature if it hasn't been merged via a pull request. Override with the -f flag.
