### PR TITLE
Force deletion of local branch, ignoring unmerged changes when cancellin...

### DIFF
--- a/git-hf-feature
+++ b/git-hf-feature
@@ -682,7 +682,7 @@ cmd_cancel() {
 			git checkout "$DEVELOP_BRANCH"
 		fi
 
-		git branch -d "$BRANCH"
+		git branch -D "$BRANCH"
 	fi
 
 	echo


### PR DESCRIPTION
...g a feature

When cancelling a feature, the local branch isn't deleted due to unmerged changes, e.g.:

```
$ git hf feature cancel test_feature
```

```
To git@github.com:user/repo.git
 - [deleted]         feature/test_feature
error: The branch 'feature/test_feature' is not fully merged.
If you are sure you want to delete it, run 'git branch -D feature/test_feature'.
```
