### PR TITLE
Feature/fix feature editor to use environment vars instead of editor command

### DIFF
--- a/git-hf-feature
+++ b/git-hf-feature
@@ -274,7 +274,7 @@ cmd_submit() {
 # including a summary of backwards-compatibility breaks, wrapped at
 # 80 characters.
 EOS
-	editor "$PR_FILE"
+	${VISUAL:-${EDITOR:-vi}} "$PR_FILE"
 
 	# extract pull request parameters from description
 	if [ -r "$PR_FILE" ]; then


### PR DESCRIPTION
Change to use $VISUAL and $EDITOR for better cross-platform support (particularly OS X).
