### PR TITLE
Add call to load the settings that were just written prior to a push

### DIFF
--- a/git-hf-init
+++ b/git-hf-init
@@ -344,6 +344,9 @@ cmd_default() {
 	# at this point, we should be on the develop branch, which may or
 	# may not exist at origin
 	#
+        # Load the settings that were just written so that $ORIGIN,
+	# etc. are properly defined
+        hubflow_load_settings
 	# push up to origin, in case this branch does not exist there (yet)
 	hubflow_push_latest_changes_to_origin
 }


### PR DESCRIPTION
The branch push uses $ORIGIN, so the settings that were just created need to be reloaded to the global vars
