### PR TITLE
Setup tracking config correctly

### DIFF
--- a/hubflow-common
+++ b/hubflow-common
@@ -402,7 +402,7 @@ hubflow_push_latest_changes_to_origin() {
 
         # configure remote tracking
         git config "branch.$current_branch.remote" "$ORIGIN"
-        git config "branch.$current_branch.merge" "refs/heads/$ORIGIN"
+        git config "branch.$current_branch.merge" "refs/heads/$current_branch"
 
         # we're done
         return 1


### PR DESCRIPTION
.. to avoid 'git push' resulting in new remote branch called 'origin'
after 'git hf feature start my-fancy-branch-name-goes-here'
