### PR TITLE
Deleting the COMMIT_MSG file after successful submit

### DIFF
--- a/git-hf-feature
+++ b/git-hf-feature
@@ -319,6 +319,9 @@ EOS
 
 	if [ -z "$PR_URL" ]; then
 		die "Failed to create Pull Request"
+	else
+		# if it succeed, delete the pull request file
+		rm -f "$PR_FILE"
 	fi
 
 	echo


### PR DESCRIPTION
Fixes #56 where the COMMIT_MSG would remain after successful `git hf feature submit`
