### PR TITLE
Feature checkout to non-existent local branch sets tracking properly.

### DIFF
--- a/git-hf-feature
+++ b/git-hf-feature
@@ -449,12 +449,12 @@ cmd_checkout() {
 	parse_args "$@"
 
 	if [ "$NAME" != "" ]; then
-	   if git rev-parse "$BRANCH" &> /dev/null ; then
-		expand_nameprefix_arg
-		git checkout "$BRANCH"
-	   else
-		git checkout -b "$BRANCH" "$ORIGIN/$BRANCH"
-	   fi
+		if git rev-parse "$BRANCH" &> /dev/null ; then
+			expand_nameprefix_arg
+			git checkout "$BRANCH"
+		else
+			git checkout -b "$BRANCH" "$ORIGIN/$BRANCH"
+		fi
 	else
 		die "Name a feature branch explicitly."
 	fi


### PR DESCRIPTION
In other words, set tracking for the new branch to $ORIGIN/$FEATURE instead of develop.
