### PR TITLE
Specifying ORIGIN on 'git remote update'.

### DIFF
--- a/hubflow-common
+++ b/hubflow-common
@@ -354,7 +354,7 @@ hubflow_local_merge_helper() {
 }
 
 hubflow_fetch_latest_changes_from_origin() {
-    git remote update || die "Unable to get list of latest changes from '$ORIGIN'"
+    git remote update "$ORIGIN" || die "Unable to get list of latest changes from '$ORIGIN'"
     git fetch "$ORIGIN" || die "Unable to fetch latest changes from '$ORIGIN'"
     git fetch --tags  || die "Unable to fetch latest tags from '$ORIGIN'"
 }


### PR DESCRIPTION
Github, Bitbucket, etc. are typically used as origin and they're fast but production and staging servers can be slow (especially Heroku). They also don't contain feature/hotfix branches in the Gitflow workflow.
The constant fetching of my staging and production servers was just a consistant minor annoyance.
