### PR TITLE
Fix: Use $HUBFLOW_REPO for updates

### DIFF
--- a/hubflow-common
+++ b/hubflow-common
@@ -508,7 +508,7 @@ hubflow_push_latest_changes_to_origin() {
 }
 
 hubflow_get_latest_version_number() {
-	LATEST="`git ls-remote --tags https://github.com/datasift/gitflow | grep -v '\^' | tail -n 1 | cut -d / -f 3`"
+	LATEST="`git ls-remote --tags $HUBFLOW_REPO | grep -v '\^' | tail -n 1 | cut -d / -f 3`"
 
 	echo $LATEST
 }


### PR DESCRIPTION
Version check and upgrade use the same URL.

Sorry if this isn't the right branch to submit a PR against.
