### PR TITLE
Added support for -w to diff

### DIFF
--- a/Changes.mdown
+++ b/Changes.mdown
@@ -8,6 +8,9 @@ Release date: **not yet**
 * `git flow feature finish` can now be called without a feature branch
   name(prefix) argument and will finish the current branch, if on any.
 
+* `git flow feature diff` now has a `-w` flag for `diff --ignore-all-space`
+  (thanks Norbert Kiesel).
+
 * `git flow feature pull` now has a `-r` flag, to support `pull --rebase`
   semantics (thanks Vedang Manerikar).
 

--- a/git-hf-feature
+++ b/git-hf-feature
@@ -459,19 +459,24 @@ cmd_finish() {
 }
 
 cmd_diff() {
+	DEFINE_boolean ignore_all_space false 'Ignore changes in amount of whitespace' w
 	parse_args "$@"
 
+	local OPTS=
+	if flag ignore_all_space; then
+		OPTS="$OPTS -w"
+	fi
 	if [ "$NAME" != "" ]; then
 		expand_nameprefix_arg
 		BASE=$(git merge-base "$DEVELOP_BRANCH" "$FEATURE_BRANCH")
-		git diff "$BASE..$FEATURE_BRANCH"
+		git diff $OPTS "$BASE..$FEATURE_BRANCH"
 	else
 		if ! git_current_branch | grep -q "^$FEATURE_PREFIX"; then
 			die "Not on a feature branch. Name one explicitly."
 		fi
 
 		BASE=$(git merge-base "$DEVELOP_BRANCH" HEAD)
-		git diff "$BASE"
+		git diff $OPTS "$BASE"
 	fi
 }
 


### PR DESCRIPTION
I often need -w for my git diffs due to inconsistent whitespace usage in one of my projects.  So this simply adds a `-w` to `git hf feature` 
