### PR TITLE
Fix hubflow_branch_pop_no_checkout stack cleanup

### DIFF
--- a/hubflow-common
+++ b/hubflow-common
@@ -268,7 +268,7 @@ hubflow_branch_pop_no_checkout() {
     [[ $BRANCH_STACK_SP != 0 ]] || die "Internal error: attempt to pop from empty BRANCH_STACK"
 
     # pop the branch from the stack
-    BRANCH_STACK[$BRANCH_STACK_SP]=
+    BRANCH_STACK[$BRANCH_STACK_SP-1]=
     let "BRANCH_STACK_SP -= 1"
 }
 


### PR DESCRIPTION
By analogy with https://github.com/datasift/gitflow/commit/ddf9ee1898a947e56b5812a9d708d9583afb7c65#diff-f15ff19190e4b76e38d6307a1786372f clean correct branch stack entry.