### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ for [DataSift's HubFlow branching model](http://datasift.github.com/gitflow/), w
 Installation
 ------------
 
-1. `git clone git@github.com:datasift/gitflow.git`
+1. `git clone https://github.com/datasift/gitflow.git`
 2. `cd gitflow`
 3. `sudo ./install.sh`
 


### PR DESCRIPTION
fix
```
 git clone git@github.com:datasift/gitflow.git
Cloning into 'gitflow'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```