### PR TITLE
Fix dead links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@ HubFlow
 =======
 
 Adds the 'git hf' Git extension to provide high-level repository operations
-for [DataSift's HubFlow branching model](http://datasift.github.com/gitflow/), which is based on [Vincent Driessen’s original blog post](http://nvie.com/posts/a-successful-git-branching-model/).
+for [DataSift's HubFlow branching model](https://datasift.github.io/gitflow/), which is based on [Vincent Driessen’s original blog post](https://nvie.com/posts/a-successful-git-branching-model/).
 
-![](http://nvie.com/img/2009/12/Screen-shot-2009-12-24-at-11.32.03.png)
+![Diagram of the Hubflow framework](https://www.bram.us/wordpress/wp-content/uploads/2012/08/Screen-shot-2009-12-24-at-11.32.03.png)
 
 Installation
 ------------
 
-1. `git clone git@github.com:datasift/gitflow.git`
+1. `git clone https://github.com/datasift/gitflow`
 2. `cd gitflow`
 3. `sudo ./install.sh`
 
@@ -25,12 +25,12 @@ Upgrading to the latest version of the HubFlow tools is very easy:
 Getting Started
 ---------------
 
-See our tutorial website to learn more about the [GitFlow](http://datasift.github.com/gitflow/IntroducingGitFlow.html) branching model and [how to use the HubFlow tools](http://datasift.github.com/gitflow/GitFlowForGitHub.html).
+See our tutorial website to learn more about the [GitFlow](https://datasift.github.io/gitflow/IntroducingGitFlow.html) branching model and [how to use the HubFlow tools](https://datasift.github.io/gitflow/GitFlowForGitHub.html).
 
 Changelog
 ---------
 
-To see what's new in each release, see our [Changelog](http://datasift.github.com/gitflow/ChangeLog.html).
+To see what's new in each release, see our [Changelog](https://datasift.github.io/gitflow/ChangeLog.html).
 
 License Terms
 -------------


### PR DESCRIPTION
Fixes several dead links in the readme, fixes git clone, defaults to https, fixes broken image.

As an alternative to the image I linked, you could go with https://nvie.com/img/git-model@2x.png, which is from the original blogpost. I went with the other version because it takes up less space in the readme while still being legible.